### PR TITLE
expose node-imaps move function to mail listener

### DIFF
--- a/dist/mail.listener.js
+++ b/dist/mail.listener.js
@@ -89,6 +89,7 @@
                 parser = new MailParser;
                 parser.on("end", function(mail) {
                   util.log("parsed mail" + util.inspect(mail, false, 5));
+                  mail.uid = msg.uid;
                   return _this.emit("mail:parsed", mail);
                 });
                 msg.on("data", function(data) {
@@ -103,6 +104,11 @@
           });
         }
       });
+    };
+
+    MailListener.prototype.move = function(msguids,mailboxes,cb) {
+      var _this = this;
+      return this.imap.move(msguids,mailboxes,cb);
     };
 
     return MailListener;

--- a/src/mail.listener.coffee
+++ b/src/mail.listener.coffee
@@ -67,10 +67,15 @@ class MailListener extends EventEmitter
               parser = new MailParser
               parser.on "end", (mail) =>
                 util.log "parsed mail" + util.inspect mail, false, 5
+                mail.uid = msg.uid
                 @emit "mail:parsed", mail
               msg.on "data", (data) -> parser.write data.toString()
               msg.on "end", ->
                 util.log "fetched message: " + util.inspect(msg, false, 5)
                 parser.end()
+
+  # move mailbox
+  move: (msguids, mailboxes, cb) =>
+    @imap.move msguids, mailboxes, cb
 
 module.exports = MailListener


### PR DESCRIPTION
One possible use case for this commit would be something we do is:
Move any new mails to a particular mail box.

Eg:

mailListener.move([mail.uid],['open'],function(error) {
    console.log(error);
  });
