### PR TITLE
Add a way to specify MailParser options

### DIFF
--- a/dist/mail.listener.js
+++ b/dist/mail.listener.js
@@ -16,7 +16,7 @@
 
     __extends(MailListener, _super);
 
-    function MailListener(options) {
+    function MailListener(options, parserOptions) {
       this._parseUnreadEmails = __bind(this._parseUnreadEmails, this);
       this.stop = __bind(this.stop, this);
       this.start = __bind(this.start, this);
@@ -30,6 +30,7 @@
         tls: options.secure
       });
       this.mailbox = options.mailbox || "INBOX";
+      this.parserOptions = parserOptions;
     }
 
     MailListener.prototype.start = function() {
@@ -83,7 +84,7 @@
           });
           return fetch.on("message", function(msg, id) {
             var parser;
-            parser = new MailParser;
+            parser = new MailParser(_this.parserOptions);
             parser.on("end", function(mail) {
               mail.uid = id;
               return _this.emit("mail:parsed", mail);

--- a/src/mail.listener.coffee
+++ b/src/mail.listener.coffee
@@ -5,7 +5,7 @@ Imap = require "imap"
 # MailListener class. Can `emit` events in `node.js` fashion.
 class MailListener extends EventEmitter
 
-  constructor: (options) ->
+  constructor: (options, parserOptions) ->
     # set this option to `true` if you want to fetch unread emial immediately on lib start.
     @fetchUnreadOnStart = options.fetchUnreadOnStart
     @markSeen = options.markSeen
@@ -17,6 +17,7 @@ class MailListener extends EventEmitter
       port: options.port
       tls: options.secure
     @mailbox = options.mailbox || "INBOX"
+    @parserOptions = parserOptions
 
   # start listener
   start: => 
@@ -59,7 +60,7 @@ class MailListener extends EventEmitter
         fetch = @imap.fetch(searchResults, { bodies: '', markSeen: markSeen })
         # 6. email was fetched. Parse it!   
         fetch.on "message", (msg, id) =>
-          parser = new MailParser
+          parser = new MailParser @parserOptions
           parser.on "end", (mail) =>
             mail.uid = id
             @emit "mail:parsed", mail


### PR DESCRIPTION
I want to be able to stream attachments. Currently there is no way to specify parser options.
